### PR TITLE
Made RPi board detection work for RPi 2 B and fixed misleading output

### DIFF
--- a/rpirtscts.c
+++ b/rpirtscts.c
@@ -47,7 +47,7 @@ int rpi_version() {
 	FILE *fp = fopen("/proc/cmdline", "r");
 	if (fp) {
 		while (fscanf(fp, "%255s", string) == 1)
-			if (sscanf(string, "bcm2708.boardrev=%i", &result))
+			if (sscanf(string, "bcm270%*d.boardrev=%i", &result))
 				break;
 		fclose(fp);
 	}
@@ -104,12 +104,14 @@ void set_rts_cts(int enable) {
 	if (rpi_gpio_header_type() == GPIO_header_40) { /* newer 40 pin GPIO header */
 		gfpsel = GFPSEL1;
 		gpiomask = GPIO1617mask;
-		printf("Enabling CTS0 and RTS0 on GPIOs 16 and 17\n");
+		enable ? printf("Enabling ") : printf("Disabling ");
+		printf("CTS0 and RTS0 on GPIOs 16 and 17\n");
 	}
 	else { /* 26 pin GPIO header */
 		gfpsel = GFPSEL3;
 		gpiomask = GPIO3031mask;
-		printf("Enabling CTS0 and RTS0 on GPIOs 30 and 31\n");
+		enable ? printf("Enabling ") : printf("Disabling ");
+		printf("CTS0 and RTS0 on GPIOs 30 and 31\n");
 	}
 	
 	enable ? (gpio[gfpsel] |= gpiomask) : (gpio[gfpsel] &= ~gpiomask);


### PR DESCRIPTION
On line 50 of the original code, the "sscanf"-function was looking for the phrase 'bcm2708.boardrev', which is not working for RPi 2 B models where the phrase in /proc/cmdline is 'bcm2709.boardrev'.
Secondly fixed some output that would say "Enabling..." even when disabling the ports.
